### PR TITLE
Upgrade EsClient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val mahoutVersion = "0.13.0"
 // local Maven repo, until Elasticasearch authentication PR
 // is merged & released:
 // https://github.com/apache/incubator-predictionio/pull/372
-val pioVersion = "0.11.0-SNAPSHOT"
+val pioVersion = "0.12.0-SNAPSHOT"
 
 // This Elasticsearch version must exactly match the server version.
 // On Heroku, this means the Bonsai Add-on.

--- a/template.json
+++ b/template.json
@@ -1,1 +1,1 @@
-{"pio": {"version": { "min": "0.11.0-SNAPSHOT" }}}
+{"pio": {"version": { "min": "0.12.0-SNAPSHOT" }}}


### PR DESCRIPTION
Migrate to use the Elasticsearch client with [proposed with performance fixes](https://github.com/apache/incubator-predictionio/pull/421).

This new ES client is available from the buildpack by setting the version to `0.12.0-SNAPSHOT` in **build.sbt** & **template.json**.